### PR TITLE
Catch all exceptions during celery requests.

### DIFF
--- a/server_status/__init__.py
+++ b/server_status/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-__version__ = '0.3.0'  # pragma: no cover
+__version__ = '0.3.1'  # pragma: no cover

--- a/server_status/views.py
+++ b/server_status/views.py
@@ -138,7 +138,7 @@ def get_celery_info():
         if not celery_stats:
             log.error("No running Celery workers were found.")
             return {"status": DOWN, "message": "No running Celery workers"}
-    except IOError as exp:
+    except Exception as exp:  # pylint: disable=broad-except
         log.error("Error connecting to the backend: %s", exp)
         return {"status": DOWN, "message": "Error connecting to the backend"}
     return {"status": UP, "response_microseconds": (datetime.now() - start).microseconds}


### PR DESCRIPTION
If there's an underlying redis error, we don't catch it and it 500s.