### PR TITLE
Release 0.5.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.tox
+.cache
+htmlcov
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,26 @@
-sudo: false
+sudo: required
 language: python
 services:
-- postgresql
-- elasticsearch
-- redis-server
-python:
-- 2.7
-- 3.4
-- 3.5
-- 3.6
+  - postgresql
+  - elasticsearch
+  - redis-server
+  - rabbitmq
 install:
-- pip install -U pip setuptools
-- pip install tox-travis
-- pip install -r requirements.txt -r test_requirements.txt
+  - pip install -U pip setuptools
+  - pip install tox-travis
+  - pip install -r requirements.txt -r test_requirements.txt
 before_script:
-- psql -c 'create database test_postgres;' -U postgres
-script:
-- tox
+  - psql -c 'create database test_postgres;' -U postgres
+matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=django110
+    - python: 2.7
+      env: TOX_ENV=django111
+    - python: 3.6
+      env: TOX_ENV=django110
+    - python: 3.6
+      env: TOX_ENV=django111
+    - python: 3.6
+      env: TOX_ENV=django20
+script: tox -e $TOX_ENV

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 django-server-status
 ====================
 
-Monitor server status with a healthcheck.
+Monitor server status with a healthcheck. Supports Django 1.10, 1.11 and 2.0.
 
 Installation
 ------------

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+Version 0.5.0
+-------------
+
+- Fixed assumption that celery will always use redis
+- Fixes for Django 2.0
+- Fixed typo by changing redis to PostgreSQL in log.error when checking PostgreSQL connection
+
 Version 0.4.0
 -------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,10 @@ services:
     command: elasticsearch -Des.network.host=0.0.0.0 -Des.http.cors.enabled=true -Des.http.cors.allow-origin=*
     ports:
       - "9200"
+  rabbitmq:
+    image: rabbitmq
+    ports:
+      - "5672"
   web:
     build: .
     command: 'tox'
@@ -20,8 +24,9 @@ services:
       - .:/src
     environment:
       DATABASE_HOST: db
-      BROKER_URL: redis://redis:6379/4
+      REDIS_URL: redis://redis:6379/4
       ELASTICSEARCH_URL: http://elastic:9200
+      CELERY_BROKER_URL: amqp://guest:guest@rabbitmq:5672/
     links:
       - db
       - redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-django
 six
 kombu
 redis

--- a/server_status/__init__.py
+++ b/server_status/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-__version__ = '0.4.0'  # pragma: no cover
+__version__ = '0.5.0'

--- a/server_status/tests/settings.py
+++ b/server_status/tests/settings.py
@@ -88,7 +88,8 @@ ELASTICSEARCH_URL = os.environ.get('ELASTICSEARCH_URL', 'http://127.0.0.1:9200')
 USE_CELERY = True
 STATUS_TOKEN = 'asdf'
 
-BROKER_URL = os.environ.get('BROKER_URL', 'redis://127.0.0.1:6379/4')
+BROKER_URL = os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379/4')
+CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', 'amqp://guest:guest@127.0.0.1:5672/')
 CELERY_RESULT_BACKEND = BROKER_URL
 
 HEALTH_CHECK = ['REDIS', 'ELASTIC_SEARCH', 'POSTGRES', 'CELERY']

--- a/server_status/tests/urls.py
+++ b/server_status/tests/urls.py
@@ -1,10 +1,14 @@
 """URLs to run the tests."""
-from django.conf.urls import include, url
+try:
+    from django.urls import include
+except ImportError:
+    from django.conf.urls import include
+from django.conf.urls import url
 from django.contrib import admin
 
 admin.autodiscover()
 
 urlpatterns = (
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^status', include('server_status.urls')),
 )

--- a/server_status/views.py
+++ b/server_status/views.py
@@ -53,7 +53,7 @@ def get_pg_info():
         micro = (datetime.now() - start).microseconds
         connection.close()
     except (OperationalError, KeyError) as ex:
-        log.error("No redis connection info found in settings. %s Error: %s",
+        log.error("No PostgreSQL connection info found in settings. %s Error: %s",
                   conf, ex)
         return {"status": DOWN}
     log.debug("got to end of postgres check successfully")

--- a/server_status/views_test.py
+++ b/server_status/views_test.py
@@ -9,12 +9,14 @@ import logging
 import mock
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+
 from django.test import Client
 from django.test.utils import override_settings
 from django.test.testcases import TestCase
+from django.urls import reverse
 
 from server_status import views
+
 
 log = logging.getLogger(__name__)
 
@@ -47,7 +49,11 @@ class TestStatus(TestCase):
 
     def test_view(self):
         """Get normally."""
-        with mock.patch('celery.task.control.inspect', autospec=True) as mocked:
+        with mock.patch(
+            'celery.task.control.inspect', autospec=True,
+        ) as mocked, mock.patch(
+            'celery.Celery', autospec=True
+        ):
             mocked.return_value.stats.return_value = {'foo': 'bar'}
             resp = self.get()
         for key in ("postgresql", "redis", "elasticsearch", "celery"):
@@ -62,7 +68,6 @@ class TestStatus(TestCase):
         """
         # remove the default one that should be in the settings (it should be tested in test_view)
         assert hasattr(settings, 'BROKER_URL')
-        assert not hasattr(settings, 'CELERY_BROKER_URL')
         assert not hasattr(settings, 'REDIS_URL')
         redis_url = settings.BROKER_URL
         del settings.BROKER_URL
@@ -76,12 +81,14 @@ class TestStatus(TestCase):
     @override_settings(USE_CELERY=False)
     def test_no_settings(self):
         """Missing settings."""
-        (broker_url, databases, elastic_connections) = (
+        (celery_broker_url, broker_url, databases, elastic_connections) = (
+            settings.CELERY_BROKER_URL,
             settings.BROKER_URL,
             settings.DATABASES,
             settings.ELASTICSEARCH_URL
         )
         try:
+            del settings.CELERY_BROKER_URL
             del settings.BROKER_URL
             del settings.DATABASES
             del settings.ELASTICSEARCH_URL
@@ -90,10 +97,11 @@ class TestStatus(TestCase):
                 self.assertTrue(resp[key]["status"] == views.NO_CONFIG)
         finally:
             (
+                settings.CELERY_BROKER_URL,
                 settings.BROKER_URL,
                 settings.DATABASES,
                 settings.ELASTICSEARCH_URL,
-            ) = (broker_url, databases, elastic_connections)
+            ) = (celery_broker_url, broker_url, databases, elastic_connections)
 
     def test_broken_settings(self):
         """Settings that couldn't possibly work."""
@@ -101,12 +109,13 @@ class TestStatus(TestCase):
         databases = deepcopy(settings.DATABASES)
         databases['default'] = junk
         with self.settings(
-            BROKER_URL=junk,
+            CELERY_BROKER_URL=junk,
+            REDIS_URL='redis://{}'.format(junk),
             DATABASES=databases,
             ELASTICSEARCH_URL=junk,
         ):
             resp = self.get(SERVICE_UNAVAILABLE)
-            for key in ("postgresql", "redis", "elasticsearch"):
+            for key in ("celery", "postgresql", "redis", "elasticsearch"):
                 self.assertTrue(resp[key]["status"] == views.DOWN,
                                 "%s - %s" % (key, resp[key]))
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,8 +5,8 @@ ipdb
 mixer
 mock
 pdbpp
-pylint-django==0.7.2
-pylint==1.7.1
+pylint-django
+pylint==1.8.2
 pytest
 pytest-cov
 pytest-django

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py{27,34,35,36}-django{110,111,20}
 skip_missing_interpreters = True
 skipsdist = True
 
@@ -7,10 +7,8 @@ skipsdist = True
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
-commands =
-	py.test {posargs}
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
+    django20: Django>=2.0
+commands = py.test {posargs}
 passenv = *
-setenv =
-    DATABASE_HOST: db
-    BROKER_URL: redis://redis:6379/4
-    ELASTICSEARCH_URL: http://elastic:9200


### PR DESCRIPTION
## Tobias Macey
  - [x] Fixed assumption that celery will always use redis ([c14dc7ad](../commit/c14dc7ad14b56eac245fa0ad4e6a5fed11395754))

## George Schneeloch
  - [x] Fixes for Django 2.0 ([5dd555d1](../commit/5dd555d165307dc60db2a7b73c6cf68a2df700dd))

## sar
  - [x] Fixed typo by changing redis to PostgreSQL in log.error when checking PostgreSQL connection ([c543be9a](../commit/c543be9ae25967dbc566af5fbffa293d5483253f))
