### PR TITLE
Update django-server-status to fix deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,8 @@ matrix:
       env: TOX_ENV=django20
     - python: 3.7
       env: TOX_ENV=django30
-    - python: 3.7
-      env: TOX_ENV=django40
     - python: 3.8
       env: TOX_ENV=django20
     - python: 3.8
       env: TOX_ENV=django30
-    - python: 3.8
-      env: TOX_ENV=django40
 script: tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,16 @@ before_script:
   - psql -c 'create database test_postgres;' -U postgres
 matrix:
   include:
-    - python: 2.7
-      env: TOX_ENV=django110
-    - python: 2.7
-      env: TOX_ENV=django111
-    - python: 3.6
-      env: TOX_ENV=django110
-    - python: 3.6
-      env: TOX_ENV=django111
-    - python: 3.6
+    - python: 3.7
       env: TOX_ENV=django20
+    - python: 3.7
+      env: TOX_ENV=django30
+    - python: 3.7
+      env: TOX_ENV=django40
+    - python: 3.8
+      env: TOX_ENV=django20
+    - python: 3.8
+      env: TOX_ENV=django30
+    - python: 3.8
+      env: TOX_ENV=django40
 script: tox -e $TOX_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.8
 MAINTAINER ODL DevOps <mitx-devops@mit.edu>
 
 # Add package files
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 # Install base packages
 RUN apt-get update
-RUN apt-get install -y postgresql-client python-dev python3-dev
+RUN apt-get install -y postgresql-client python3-dev
 
 # Add non-root user.
 RUN adduser --disabled-password --gecos "" mitodl
@@ -15,9 +15,7 @@ RUN adduser --disabled-password --gecos "" mitodl
 COPY requirements.txt /tmp/requirements.txt
 COPY test_requirements.txt /tmp/test_requirements.txt
 
-RUN pip install -U pip
 RUN pip3 install -U pip
-RUN pip install -r requirements.txt -r test_requirements.txt
 RUN pip3 install -r requirements.txt -r test_requirements.txt
 
 # Add project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,9 @@ services:
     ports:
       - "6379"
   elastic:
-    image: elasticsearch:2.4.1
-    command: elasticsearch -Des.network.host=0.0.0.0 -Des.http.cors.enabled=true -Des.http.cors.allow-origin=*
+    image: elasticsearch:6.7.1
+    command: elasticsearch -E network.host=0.0.0.0 -E http.cors.enabled=true -E http.cors.allow-origin=* -E rest.action.multi.allow_explicit_index=false
+    user: elasticsearch
     ports:
       - "9200"
   rabbitmq:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
-addopts = --cov server_status --pep8 --pylint --cov-report term --cov-report html --ds=server_status.tests.settings -p no:warnings
+addopts = --cov server_status --pylint --cov-report term --cov-report html --ds=server_status.tests.settings -p no:warnings
 norecursedirs = .git .tox .* CVS _darcs {arch} *.egg
-pep8maxlinelength = 119
 filterwarnings =
     error
     ignore::DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 addopts = --cov server_status --pep8 --pylint --cov-report term --cov-report html --ds=server_status.tests.settings -p no:warnings
 norecursedirs = .git .tox .* CVS _darcs {arch} *.egg
 pep8maxlinelength = 119
+filterwarnings =
+    error
+    ignore::DeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# django handled separately

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-six
-kombu
-redis
-psycopg2
-elasticsearch
-celery
-pyopenssl==17.5.0

--- a/server_status/views.py
+++ b/server_status/views.py
@@ -26,7 +26,7 @@ SERVICE_UNAVAILABLE = 503
 TIMEOUT_SECONDS = 5
 
 
-# pylint: disable=too-many-locals
+# pylint: disable=too-many-locals, import-outside-toplevel
 def get_pg_info():
     """Check PostgreSQL connection."""
     from psycopg2 import connect, OperationalError
@@ -200,7 +200,7 @@ def status(request):  # pylint: disable=unused-argument
     for setting, (check_fn, key) in check_mapping.items():
         if setting in settings.HEALTH_CHECK:
             log.debug('getting: %s', key)
-            info[key] = check_fn()
+            info[key] = check_fn()  # pylint: disable=not-callable
             log.debug('%s done', key)
 
     code = HTTP_OK

--- a/server_status/views_test.py
+++ b/server_status/views_test.py
@@ -53,7 +53,7 @@ class TestStatus(TestCase):
     def test_view(self):
         """Get normally."""
         with mock.patch(
-            'celery.task.control.inspect', autospec=True,
+                'celery.task.control.inspect', autospec=True,
         ) as mocked, mock.patch(
             'celery.Celery', autospec=True
         ):
@@ -144,10 +144,10 @@ class TestStatus(TestCase):
         databases = deepcopy(settings.DATABASES)
         databases['default'] = junk
         with self.settings(
-            CELERY_BROKER_URL=junk,
-            REDIS_URL='redis://{}'.format(junk),
-            DATABASES=databases,
-            ELASTICSEARCH_URL=junk,
+                CELERY_BROKER_URL=junk,
+                REDIS_URL='redis://{}'.format(junk),
+                DATABASES=databases,
+                ELASTICSEARCH_URL=junk,
         ):
             resp = self.get(SERVICE_UNAVAILABLE)
             for key in ("celery", "postgresql", "redis", "elasticsearch"):
@@ -161,9 +161,9 @@ class TestStatus(TestCase):
         databases = deepcopy(settings.DATABASES)
         databases["default"]["HOST"] = "monkey"
         with self.settings(
-            BROKER_URL="redis://bogus:6379/4",
-            DATABASES=databases,
-            ELASTICSEARCH_URL="pizza:2300"
+                BROKER_URL="redis://bogus:6379/4",
+                DATABASES=databases,
+                ELASTICSEARCH_URL="pizza:2300"
         ):
             resp = self.get(SERVICE_UNAVAILABLE)
             for key in ("postgresql", "redis", "elasticsearch"):

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,6 @@ from setuptools import setup, find_packages
 import server_status as app
 
 # pylint: disable=invalid-name
-dev_requires = [
-    'flake8',
-]
-
 install_requires = open('requirements.txt').read().splitlines()
 
 
@@ -61,8 +57,5 @@ setup(
     url="https://github.com/mitodl/django-server-status",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=install_requires,
-    extras_require={
-        'dev': dev_requires,
-    },
+    install_requires=["django"] + install_requires,
 )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,7 @@
+celery
 coverage
 ddt
+elasticsearch
 fabric
 flake8
 freezegun
@@ -7,11 +9,13 @@ ipdb
 mixer
 mock
 pdbpp
-pylint-django
-pylint==1.8.2
+psycopg2
+pyopenssl
+pylint-django==2.3.0
+pylint==2.5.3
 pytest
 pytest-cov
 pytest-django
-pytest-pep8
-pytest-pylint==0.6.0
+pytest-pylint==0.17.0
+redis
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}-django{110,111,20}
+envlist = py{37, 38}-django{20, 30, 40}
 skip_missing_interpreters = True
 skipsdist = True
 
@@ -7,8 +7,6 @@ skipsdist = True
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
-    django110: Django>=1.10,<1.11
-    django111: Django>=1.11,<2.0
     django20: Django>=2.0
 commands = py.test {posargs}
 passenv = *

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{37, 38}-django{20, 30, 40}
+envlist = py{37, 38}-django{20, 30}
 skip_missing_interpreters = True
-skipsdist = True
 
 [testenv]
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
-    django20: Django>=2.0
+    django20: Django>=2.0, <3
+    django30: Django>=3.0, <4
 commands = py.test {posargs}
 passenv = *


### PR DESCRIPTION
A few changes are made:
 - Tests are now run against Python 3.7 and 3.8, and against Django 2.x and 3.x. Django 1.x and Python 2.x are not supported.
 - pylint-pep8 removed due to a bug. I think we should migrate to black rather than figuring out a workaround to this.
 - I removed all of `requirements.txt` and moved those items to `test_requirements.txt`. It seems like django is our only hard requirement for this so it should be our only dependency.