### PR TITLE
Fix description handling for packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,15 @@ import server_status as app
 install_requires = open('requirements.txt').read().splitlines()
 
 
-def read(filename):
+def read(filename, is_restructured_text=False):
     """Helper function to read bytes from file"""
     try:
-        return open(os.path.join(os.path.dirname(__file__), filename)).read()
+        text = open(os.path.join(os.path.dirname(__file__), filename)).read()
+        if is_restructured_text:
+            # See https://packaging.python.org/specifications/core-metadata/#description
+            # any newline has to be suffixed by 7 spaces and a pipe character
+            text = text.replace("\n", "\n       |")
+        return text
     except IOError:
         return ''
 
@@ -48,7 +53,7 @@ setup(
     name="django-server-status",
     version=app.__version__,
     description=read('DESCRIPTION'),
-    long_description=read('README.rst'),
+    long_description=read('README.rst', is_restructured_text=True),
     license='The AGPL License',
     platforms=['OS Independent'],
     keywords='django, monitoring, health check',


### PR DESCRIPTION
When we tried to upload this package to pypi, we got this error:

    Checking dist/django_server_status-0.7.1-py3-none-any.whl: FAILED
      `long_description` has syntax errors in markup and would not be rendered on PyPI.
        line 6: Error: Unexpected indentation.
      warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
    Checking dist/django-server-status-0.7.1.tar.gz: FAILED
      `long_description` has syntax errors in markup and would not be rendered on PyPI.
        line 6: Error: Unexpected indentation.
      warning: `long_description_content_type` missing. defaulting to `text/x-rst`.

The problem is that newlines in the description field is not handled properly by the packaging tool. The `line 6` part is misleading above. `README.rst` is valid restructured text but the `METADATA` of the wheel looks like this:

![Screenshot from 2020-09-18 10-14-45](https://user-images.githubusercontent.com/863262/93610395-0063a980-f99b-11ea-828b-26c074833736.png)

`line 6` refers to the indentation within the `METADATA` file, not the `README.rst` file. From [the docs](https://packaging.python.org/specifications/core-metadata/#description) it looks like Metadata format 1.1 was agnostic on this but Metadata 2.1 specifically requires newlines to have 7 spaces and a `|` after each newline character. This attempts to fix the issue by handling this in the setup.py file.